### PR TITLE
Add new dashboard UI flow and creatorId in poll payload

### DIFF
--- a/dashboard/api/dashboard-commands.js
+++ b/dashboard/api/dashboard-commands.js
@@ -456,6 +456,7 @@ router.get('/context-targets/polls', validateDashboardToken, async (req, res) =>
         title: poll.titulo,
         options: poll.opcoes || [],
         status: poll.status,
+        creatorId: poll.criadoPor || poll.criadorId || null,
       }))
       .filter((poll) => poll.status === 'ativa');
 

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -13,6 +13,11 @@ import {
   uploadCsv,
 } from './api';
 
+import Layout from './components/ui/Layout';
+import Panel from './components/ui/Panel';
+import GuildChannelSelector from './components/ui/GuildChannelSelector';
+import CommandPanel from './components/ui/CommandPanel';
+
 const CSV_COLUMNS = [
   {
     order: 1,
@@ -146,6 +151,14 @@ function isSameRascunhoForm(left, right) {
   );
 }
 
+function getUserNameById(userId, members) {
+  if (!userId) return null;
+  if (!members?.length) return null;
+  const user = members.find((member) => member.id === userId || member.userId === userId);
+  if (!user) return null;
+  return user.displayName || user.username || user.name || null;
+}
+
 const CSV_COMMAND_KEY = 'csv:upload';
 const FEEDBACK_TIMEOUT_MS = 4000;
 const MODERATION_COMMAND_ORDER = ['criador-de-enquete', 'mensalista'];
@@ -171,6 +184,7 @@ export default function App() {
   const [loadingSession, setLoadingSession] = useState(true);
   const [session, setSession] = useState(null);
   const [sessionError, setSessionError] = useState('');
+  const [currentSection, setCurrentSection] = useState('painel');
 
   const [guilds, setGuilds] = useState([]);
   const [guildsLoading, setGuildsLoading] = useState(true);
@@ -187,6 +201,7 @@ export default function App() {
   const [criadorIds, setCriadorIds] = useState([]);
 
   const [channels, setChannels] = useState([]);
+  const [channelsLoading, setChannelsLoading] = useState(false);
   const [selectedChannelId, setSelectedChannelId] = useState('');
   const [pollTargets, setPollTargets] = useState([]);
   const [draftTargets, setDraftTargets] = useState([]);
@@ -199,6 +214,32 @@ export default function App() {
   const [commandFeedbackByKey, setCommandFeedbackByKey] = useState({});
   const commandFeedbackTimersRef = useRef({});
   const csvFeedbackTimerRef = useRef(null);
+
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+    return window.matchMedia('(max-width: 600px)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia('(max-width: 600px)');
+    const handler = (event) => setIsMobile(event.matches);
+    handler(mediaQuery);
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handler);
+    } else {
+      mediaQuery.addListener(handler);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener('change', handler);
+      } else {
+        mediaQuery.removeListener(handler);
+      }
+    };
+  }, []);
 
   const [enqueteForm, setEnqueteForm] = useState({
     titulo: '',
@@ -230,6 +271,24 @@ export default function App() {
     };
   }, [catalog]);
 
+  const commandsDisabled = !selectedGuildId || !selectedChannelId;
+
+  const selectedGuildChannelIds = useMemo(() => {
+    if (!selectedGuildId) return [];
+    return channels.map((channel) => channel.id);
+  }, [channels, selectedGuildId]);
+
+  const currentPollTargets = useMemo(() => {
+    if (!selectedGuildId) return [];
+    return pollTargets.filter((poll) => selectedGuildChannelIds.includes(poll.channelId));
+  }, [pollTargets, selectedGuildChannelIds, selectedGuildId]);
+
+  const currentDraftTargets = useMemo(() => {
+    if (!selectedGuildId) return [];
+    // fallback for drafts without guild info
+    return draftTargets.filter((draft) => !draft.guildId || draft.guildId === selectedGuildId);
+  }, [draftTargets, selectedGuildId]);
+
   useEffect(() => {
     async function bootstrapSession() {
       try {
@@ -240,7 +299,7 @@ export default function App() {
 
         const loadedGuilds = guildsPayload.guilds || [];
         setGuilds(loadedGuilds);
-        setSelectedGuildId(loadedGuilds[0]?.id || payload.user.guildId || '');
+        setSelectedGuildId(''); // não selecionar automaticamente, força o usuário escolher
 
         const loadedCatalog = (catalogPayload.commands || []).sort((a, b) => a.name.localeCompare(b.name, 'pt-BR'));
         setCatalog(loadedCatalog);
@@ -261,6 +320,7 @@ export default function App() {
     if (!selectedGuildId || !session) return;
 
     setSelectedChannelId('');
+    setChannelsLoading(true);
 
     async function loadGuildStaticData() {
       try {
@@ -285,6 +345,8 @@ export default function App() {
         setDraftTargets([]);
         setMensalistaIds([]);
         setCriadorIds([]);
+      } finally {
+        setChannelsLoading(false);
       }
     }
 
@@ -1067,143 +1129,218 @@ export default function App() {
   }
 
   return (
-    <main className="app-shell">
-      <header className="card header-card">
-        <div>
-          <h1>Dashboard Little Boat Poll</h1>
-          <p>
+    <Layout
+      currentSection={currentSection}
+      onNavigate={setCurrentSection}
+      user={session}
+      onLogout={handleLogout}
+      isMobile={isMobile}
+      sidebarConfig={{
+        guilds,
+        guildsLoading,
+        selectedGuildId,
+        setSelectedGuildId,
+        channels,
+        channelsLoading,
+        selectedChannelId,
+        setSelectedChannelId,
+      }}
+    >
+      <Panel title="Acesso do Usuário">
+        <div className="user-access-row">
+          <span>
             Logado como <strong>{session.username}</strong>
-          </p>
+          </span>
+          <button className="button secondary" onClick={handleLogout} type="button">
+            Sair
+          </button>
         </div>
-        <button className="button secondary" onClick={handleLogout} type="button">
-          Sair
-        </button>
-      </header>
+      </Panel>
 
-      <section className="card">
-        <h2>Servidor</h2>
-        {guildsLoading ? (
-          <p>Carregando servidores...</p>
-        ) : (
-          <>
-            <div className="guild-cards">
-              {guilds.map((guild) => (
-                <button
-                  key={guild.id}
-                  type="button"
-                  className={`guild-card ${selectedGuildId === guild.id ? 'selected' : ''}`}
-                  onClick={() => setSelectedGuildId(guild.id)}
-                >
-                  {guild.icon ? <img src={guild.icon} alt={guild.name} className="guild-avatar" /> : <span>🛳️</span>}
-                  <div>
-                    <strong>{guild.name}</strong>
-                    <p>{guild.isActive ? 'Servidor ativo' : 'Servidor disponível'}</p>
+      {currentSection === 'painel' && (
+        <>
+          <Panel title="Bem-vindo ao ⛵">
+            <p style={{ marginBottom: 12 }}>Sua central administrativa para gerenciar enquetes com agilidade.</p>
+
+            <p style={{ marginBottom: 16 }}>Após escolher o seu servidor e canal, você pode:</p>
+
+            <ul style={{ display: 'flex', flexDirection: 'column', gap: 12, paddingLeft: 16 }}>
+              <li>
+                <strong>Comandos Rápidos</strong>
+                <br />
+                No menu <strong>Comandos</strong>, selecione o servidor e o canal para interagir em tempo real.
+              </li>
+
+              <li>
+                <strong>Gestão em Massa</strong>
+                <br />
+                Utilize a <strong>Importação CSV</strong> para criar várias enquetes de uma só vez.
+              </li>
+
+              <li>
+                <strong>Foco no que importa</strong>
+                <br />
+                Suas seleções de servidor e canal são mantidas automaticamente enquanto você navega, evitando
+                configurações repetitivas.
+              </li>
+            </ul>
+          </Panel>
+
+          {selectedGuildId ? (
+            <Panel title="Resumo de Enquetes">
+              <div className="dashboard-stats-grid">
+                <div className="stat-card">
+                  <strong>{currentPollTargets.length}</strong>
+                  <span>Enquetes ativas</span>
+                </div>
+
+                <div className="stat-card">
+                  <strong>{currentDraftTargets.length}</strong>
+                  <span>Rascunhos disponíveis</span>
+                </div>
+              </div>
+            </Panel>
+          ) : (
+            <Panel title="Resumo de Enquetes">
+              <p>Selecione um servidor para visualizar as estatísticas.</p>
+            </Panel>
+          )}
+        </>
+      )}
+
+      {currentSection === 'comandos' && (
+        <>
+          {isMobile && (
+            <Panel title="Servidor e Canal">
+              <GuildChannelSelector
+                guilds={guilds}
+                guildsLoading={guildsLoading}
+                selectedGuildId={selectedGuildId}
+                setSelectedGuildId={setSelectedGuildId}
+                channels={channels}
+                channelsLoading={channelsLoading}
+                selectedChannelId={selectedChannelId}
+                setSelectedChannelId={setSelectedChannelId}
+              />
+            </Panel>
+          )}
+
+          <Panel>
+            {catalogLoading ? (
+              <p>Carregando catálogo de comandos...</p>
+            ) : (
+              <div className={`command-groups ${commandsDisabled ? 'commands-disabled' : ''}`}>
+                <div className="command-group-column">
+                  <div className="command-list">
+                    {dashboardCommandGroups.polls.map((command) => (
+                      <CommandPanel
+                        key={`${command.type}:${command.name}`}
+                        command={command}
+                        expanded={expandedCommandKey === `${command.type}:${command.name}`}
+                        onToggle={toggleCommandPanel}
+                        onSubmit={handleCommandSubmit}
+                        renderCommandForm={renderCommandForm}
+                        loading={commandLoadingKey === `${command.type}:${command.name}`}
+                        feedback={commandFeedbackByKey[`${command.type}:${command.name}`] || ''}
+                        fallbackDescription="Comando de enquete"
+                        commandTypeLabel={commandTypeLabel}
+                        getDisplayCommandLabel={getDisplayCommandLabel}
+                        disabled={commandsDisabled}
+                      />
+                    ))}
                   </div>
-                </button>
-              ))}
-            </div>
+                </div>
 
-            {selectedGuildId && (
-              <div className={`channel-selector-row ${!selectedChannelId ? 'channel-required' : ''}`}>
-                <label htmlFor="global-channel-select">Canal de publicação</label>
-                <select
-                  id="global-channel-select"
-                  value={selectedChannelId}
-                  onChange={(event) => setSelectedChannelId(event.target.value)}
-                >
-                  <option value="">Selecione um canal...</option>
-                  {channels.map((channel) => (
-                    <option key={channel.id} value={channel.id}>
-                      #{channel.name}
-                    </option>
-                  ))}
-                </select>
-                {!selectedChannelId && (
-                  <p className="channel-hint">⚠️ Selecione um canal antes de executar comandos de slash.</p>
-                )}
+                <div className="command-group-column">
+                  <div className="command-list">
+                    {dashboardCommandGroups.moderation.map((command) => (
+                      <CommandPanel
+                        key={`${command.type}:${command.name}`}
+                        command={command}
+                        expanded={expandedCommandKey === `${command.type}:${command.name}`}
+                        onToggle={toggleCommandPanel}
+                        onSubmit={handleCommandSubmit}
+                        renderCommandForm={renderCommandForm}
+                        loading={commandLoadingKey === `${command.type}:${command.name}`}
+                        feedback={commandFeedbackByKey[`${command.type}:${command.name}`] || ''}
+                        fallbackDescription="Comando de moderação"
+                        commandTypeLabel={commandTypeLabel}
+                        getDisplayCommandLabel={getDisplayCommandLabel}
+                        disabled={commandsDisabled}
+                      />
+                    ))}
+                  </div>
+                </div>
               </div>
             )}
-          </>
-        )}
-      </section>
+          </Panel>
+        </>
+      )}
 
-      <section className="card">
-        {catalogLoading ? (
-          <p>Carregando catálogo de comandos...</p>
-        ) : (
-          <div className={`command-groups ${!selectedChannelId ? 'commands-disabled' : ''}`}>
+      {currentSection === 'importacao' && (
+        <Panel title="Importação CSV">
+          <p>Use essa seção para importar enquetes a partir de planilhas CSV.</p>
+          <ul>
+            <li>Baixe o modelo de CSV na seção de instruções abaixo.</li>
+            <li>Preencha 4 colunas: nome-da-enquete, opcoes, max_votos, peso_mensalistas.</li>
+            <li>Envie o arquivo e aguarde a confirmação de sucesso.</li>
+            <li>Após o upload, sua enquete ficará como rascunho para publicação na área de Comandos.</li>
+          </ul>
+
+          <div className="command-groups">
             <div className="command-group-column">
-              <h3>Comandos de Enquete</h3>
               <div className="command-list">
-                {dashboardCommandGroups.polls.map((command) => renderCommandOption(command, 'Comando de enquete'))}
-              </div>
-            </div>
-
-            <div className="command-group-column">
-              <h3>Moderação</h3>
-              <div className="command-list">
-                {dashboardCommandGroups.moderation.map((command) =>
-                  renderCommandOption(command, 'Comando de moderação'),
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-      </section>
-
-      <section className="card">
-        <h2>Importação</h2>
-        <div className="command-groups">
-          <div className="command-group-column">
-            <div className="command-list">
-              <div className={`command-option csv-option ${expandedCommandKey === CSV_COMMAND_KEY ? 'selected' : ''}`}>
-                <button
-                  type="button"
-                  className={`command-item ${expandedCommandKey === CSV_COMMAND_KEY ? 'selected' : ''}`}
-                  onClick={() => toggleCommandPanel(CSV_COMMAND_KEY)}
-                  aria-expanded={expandedCommandKey === CSV_COMMAND_KEY}
-                >
-                  <div className="command-item-header">
-                    <strong>Upload CSV</strong>
-                  </div>
-                  <span>Importa e cria enquetes a partir de arquivo CSV</span>
-                </button>
-
                 <div
-                  className={`command-panel ${expandedCommandKey === CSV_COMMAND_KEY ? 'expanded' : ''}`}
-                  aria-hidden={expandedCommandKey !== CSV_COMMAND_KEY}
+                  className={`command-option csv-option ${expandedCommandKey === CSV_COMMAND_KEY ? 'selected' : ''}`}
                 >
-                  <div className="command-panel-inner">
-                    <div className="command-panel-content form-grid">
-                      <form onSubmit={handleCsvSubmit} className="form-grid csv-upload-form">
-                        <label>
-                          Arquivo CSV
-                          <input
-                            type="file"
-                            accept=".csv,text/csv"
-                            onChange={(event) => setCsvFile(event.target.files?.[0] || null)}
-                          />
-                        </label>
-                        <button className="button csv-submit-button" type="submit" disabled={csvLoading}>
-                          {csvLoading ? 'Enviando...' : 'Enviar CSV'}
-                        </button>
-                      </form>
-                      <div className={`status-alert-slot ${csvFeedback ? 'visible' : ''}`}>
-                        {csvFeedback && (
-                          <div className={`status-alert ${csvFeedback === 'success' ? 'success' : 'error'}`}>
-                            {csvFeedback === 'success' ? 'Sucesso' : 'Falhou'}
-                          </div>
-                        )}
+                  <button
+                    type="button"
+                    className={`command-item ${expandedCommandKey === CSV_COMMAND_KEY ? 'selected' : ''}`}
+                    onClick={() => toggleCommandPanel(CSV_COMMAND_KEY)}
+                    aria-expanded={expandedCommandKey === CSV_COMMAND_KEY}
+                  >
+                    <div className="command-item-header">
+                      <strong>Upload CSV</strong>
+                    </div>
+                    <span>Importa e cria enquetes a partir de arquivo CSV</span>
+                  </button>
+
+                  <div
+                    className={`command-panel ${expandedCommandKey === CSV_COMMAND_KEY ? 'expanded' : ''}`}
+                    aria-hidden={expandedCommandKey !== CSV_COMMAND_KEY}
+                  >
+                    <div className="command-panel-inner">
+                      <div className="command-panel-content form-grid">
+                        <form onSubmit={handleCsvSubmit} className="form-grid csv-upload-form">
+                          <label>
+                            Arquivo CSV
+                            <input
+                              type="file"
+                              accept=".csv,text/csv"
+                              onChange={(event) => setCsvFile(event.target.files?.[0] || null)}
+                            />
+                          </label>
+                          <button className="button csv-submit-button" type="submit" disabled={csvLoading}>
+                            {csvLoading ? 'Enviando...' : 'Enviar CSV'}
+                          </button>
+                        </form>
+                        <div className={`status-alert-slot ${csvFeedback ? 'visible' : ''}`}>
+                          {csvFeedback && (
+                            <div className={`status-alert ${csvFeedback === 'success' ? 'success' : 'error'}`}>
+                              {csvFeedback === 'success' ? 'Sucesso' : 'Falhou'}
+                            </div>
+                          )}
+                        </div>
+                        <CsvFormatGuide />
                       </div>
-                      <CsvFormatGuide />
                     </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      </section>
-    </main>
+        </Panel>
+      )}
+    </Layout>
   );
 }

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -273,6 +273,8 @@ export default function App() {
 
   const commandsDisabled = !selectedGuildId || !selectedChannelId;
 
+  const isCommandDisabled = (command) => !selectedGuildId || (command.type === 1 && !selectedChannelId);
+
   const selectedGuildChannelIds = useMemo(() => {
     if (!selectedGuildId) return [];
     return channels.map((channel) => channel.id);
@@ -1245,7 +1247,7 @@ export default function App() {
                         fallbackDescription="Comando de enquete"
                         commandTypeLabel={commandTypeLabel}
                         getDisplayCommandLabel={getDisplayCommandLabel}
-                        disabled={commandsDisabled}
+                        disabled={isCommandDisabled(command)}
                       />
                     ))}
                   </div>
@@ -1266,7 +1268,7 @@ export default function App() {
                         fallbackDescription="Comando de moderação"
                         commandTypeLabel={commandTypeLabel}
                         getDisplayCommandLabel={getDisplayCommandLabel}
-                        disabled={commandsDisabled}
+                        disabled={isCommandDisabled(command)}
                       />
                     ))}
                   </div>

--- a/dashboard/frontend/src/App.jsx
+++ b/dashboard/frontend/src/App.jsx
@@ -796,7 +796,7 @@ export default function App() {
                 onChange={(event) => setRascunhoForm((prev) => ({ ...prev, id: event.target.value }))}
               >
                 <option value="">Selecione um rascunho</option>
-                {draftTargets.map((draft) => (
+                {currentDraftTargets.map((draft) => (
                   <option key={draft.id} value={draft.id}>
                     {draft.id} - {draft.title}
                   </option>

--- a/dashboard/frontend/src/components/ui/CommandPanel.jsx
+++ b/dashboard/frontend/src/components/ui/CommandPanel.jsx
@@ -1,0 +1,61 @@
+export default function CommandPanel({
+  command,
+  expanded,
+  onToggle,
+  onSubmit,
+  renderCommandForm,
+  loading,
+  feedback,
+  disabled,
+  fallbackDescription,
+  commandTypeLabel,
+  getDisplayCommandLabel,
+}) {
+  const commandKey = `${command.type}:${command.name}`;
+  const displayCommandName = getDisplayCommandLabel(command.name);
+
+  return (
+    <div key={commandKey} className={`command-option ${expanded ? 'selected' : ''}`}>
+      <button
+        type="button"
+        className={`command-item ${expanded ? 'selected' : ''} ${disabled ? 'command-item-disabled' : ''}`}
+        onClick={() => {
+          if (disabled) return;
+          onToggle(commandKey);
+        }}
+        aria-expanded={expanded}
+        disabled={disabled}
+      >
+        <div className="command-item-header">
+          <strong>{displayCommandName}</strong>
+        </div>
+        <span>{command.description || fallbackDescription}</span>
+      </button>
+
+      <div className={`command-panel ${expanded ? 'expanded' : ''}`} aria-hidden={!expanded}>
+        <div className="command-panel-inner">
+          <form onSubmit={(event) => onSubmit(event, command)} className="form-grid command-panel-content">
+            <div className="command-meta">
+              <strong>{displayCommandName}</strong>
+              <span>{commandTypeLabel(command.type)}</span>
+            </div>
+
+            {renderCommandForm(command)}
+
+            <button className="button" type="submit" disabled={loading || disabled}>
+              {loading ? 'Executando...' : 'Executar comando'}
+            </button>
+          </form>
+
+          <div className={`status-alert-slot ${feedback ? 'visible' : ''}`}>
+            {feedback && (
+              <div className={`status-alert ${feedback === 'success' ? 'success' : 'error'}`}>
+                {feedback === 'success' ? 'Sucesso' : 'Falhou'}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/ui/GuildChannelSelector.jsx
+++ b/dashboard/frontend/src/components/ui/GuildChannelSelector.jsx
@@ -1,0 +1,58 @@
+export default function GuildChannelSelector({
+  guilds,
+  guildsLoading,
+  selectedGuildId,
+  setSelectedGuildId,
+  selectedChannelId,
+  setSelectedChannelId,
+  channels,
+}) {
+  return (
+    <div>
+      <h2>Servidor</h2>
+      {guildsLoading ? (
+        <p>Carregando servidores...</p>
+      ) : (
+        <>
+          <div className="guild-cards">
+            {guilds.map((guild) => (
+              <button
+                key={guild.id}
+                type="button"
+                className={`guild-card ${selectedGuildId === guild.id ? 'selected' : ''}`}
+                onClick={() => setSelectedGuildId(guild.id)}
+              >
+                {guild.icon ? <img src={guild.icon} alt={guild.name} className="guild-avatar" /> : <span>🛳️</span>}
+                <div>
+                  <strong>{guild.name}</strong>
+                  <p>{guild.isActive ? 'Servidor ativo' : 'Servidor disponível'}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {selectedGuildId && (
+            <div className={`channel-selector-row ${!selectedChannelId ? 'channel-required' : ''}`}>
+              <label htmlFor="global-channel-select">Canal de publicação</label>
+              <select
+                id="global-channel-select"
+                value={selectedChannelId}
+                onChange={(event) => setSelectedChannelId(event.target.value)}
+              >
+                <option value="">Selecione um canal...</option>
+                {channels.map((channel) => (
+                  <option key={channel.id} value={channel.id}>
+                    #{channel.name}
+                  </option>
+                ))}
+              </select>
+              {!selectedChannelId && (
+                <p className="channel-hint">⚠️ Selecione um canal antes de executar comandos de slash.</p>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/ui/GuildChannelSelector.jsx
+++ b/dashboard/frontend/src/components/ui/GuildChannelSelector.jsx
@@ -5,7 +5,7 @@ export default function GuildChannelSelector({
   setSelectedGuildId,
   selectedChannelId,
   setSelectedChannelId,
-  channels,
+  channels = [],
 }) {
   return (
     <div>

--- a/dashboard/frontend/src/components/ui/Layout.jsx
+++ b/dashboard/frontend/src/components/ui/Layout.jsx
@@ -1,0 +1,12 @@
+import Sidebar from './Sidebar';
+
+export default function Layout({ currentSection, onNavigate, sidebarConfig, isMobile, children }) {
+  return (
+    <div className="dashboard-shell">
+      <Sidebar currentSection={currentSection} onNavigate={onNavigate} isMobile={isMobile} {...sidebarConfig} />
+      <div className="dashboard-main">
+        <div className="dashboard-content">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/frontend/src/components/ui/Panel.jsx
+++ b/dashboard/frontend/src/components/ui/Panel.jsx
@@ -1,0 +1,8 @@
+export default function Panel({ title, children }) {
+  return (
+    <section className="panel card" aria-labelledby={title ? `${title}-heading` : undefined}>
+      {title && <h2 id={`${title}-heading`}>{title}</h2>}
+      {children}
+    </section>
+  );
+}

--- a/dashboard/frontend/src/components/ui/Panel.jsx
+++ b/dashboard/frontend/src/components/ui/Panel.jsx
@@ -1,7 +1,14 @@
 export default function Panel({ title, children }) {
+  const sanitizedHeadingId = title
+    ? `${title
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, '')}-heading`
+    : undefined;
+
   return (
-    <section className="panel card" aria-labelledby={title ? `${title}-heading` : undefined}>
-      {title && <h2 id={`${title}-heading`}>{title}</h2>}
+    <section className="panel card" aria-labelledby={sanitizedHeadingId}>
+      {title && <h2 id={sanitizedHeadingId}>{title}</h2>}
       {children}
     </section>
   );

--- a/dashboard/frontend/src/components/ui/Sidebar.jsx
+++ b/dashboard/frontend/src/components/ui/Sidebar.jsx
@@ -1,0 +1,87 @@
+const items = [
+  { key: 'painel', label: 'Painel' },
+  { key: 'comandos', label: 'Comandos' },
+  { key: 'importacao', label: 'Importação CSV' },
+];
+
+export default function Sidebar({
+  currentSection,
+  onNavigate,
+  guilds = [],
+  guildsLoading = false,
+  selectedGuildId,
+  setSelectedGuildId,
+  channels = [],
+  channelsLoading = false,
+  selectedChannelId,
+  setSelectedChannelId,
+  isMobile = false,
+}) {
+  return (
+    <aside className={`sidebar ${isMobile ? 'mobile' : ''}`}>
+      <h2 className="sidebar-title">Little Boat Poll</h2>
+      <nav aria-label="Menu principal">
+        <ul className="sidebar-list">
+          {items.map((item) => (
+            <li key={item.key}>
+              <button
+                type="button"
+                className={`sidebar-item ${currentSection === item.key ? 'active' : ''}`}
+                onClick={() => onNavigate(item.key)}
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {!isMobile && (
+        <section className="sidebar-server-channel">
+          <h3>Servidor e Canal</h3>
+          {guildsLoading ? (
+            <p>Carregando...</p>
+          ) : (
+            <>
+              <label>
+                <select value={selectedGuildId || ''} onChange={(event) => setSelectedGuildId(event.target.value)}>
+                  <option value="">Escolha um servidor</option>
+                  {guilds.map((guild) => (
+                    <option key={guild.id} value={guild.id}>
+                      {guild.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <select
+                  value={selectedChannelId || ''}
+                  onChange={(event) => setSelectedChannelId(event.target.value)}
+                  disabled={!selectedGuildId || channelsLoading}
+                >
+                  <option value="" disabled>
+                    {selectedGuildId
+                      ? channelsLoading
+                        ? 'Carregando canais...'
+                        : 'Escolha um canal'
+                      : 'Escolha um servidor'}
+                  </option>
+                  {!channelsLoading &&
+                    channels.map((channel) => (
+                      <option key={channel.id} value={channel.id}>
+                        #{channel.name}
+                      </option>
+                    ))}
+                </select>
+              </label>
+            </>
+          )}
+
+          {(!selectedGuildId || !selectedChannelId) && (
+            <div className="sidebar-warning">Selecione um servidor e canal</div>
+          )}
+        </section>
+      )}
+    </aside>
+  );
+}

--- a/dashboard/frontend/src/components/ui/Sidebar.jsx
+++ b/dashboard/frontend/src/components/ui/Sidebar.jsx
@@ -43,37 +43,41 @@ export default function Sidebar({
             <p>Carregando...</p>
           ) : (
             <>
-              <label>
-                <select value={selectedGuildId || ''} onChange={(event) => setSelectedGuildId(event.target.value)}>
-                  <option value="">Escolha um servidor</option>
-                  {guilds.map((guild) => (
-                    <option key={guild.id} value={guild.id}>
-                      {guild.name}
+              <label htmlFor="sidebar-guild-select">Servidor</label>
+              <select
+                id="sidebar-guild-select"
+                value={selectedGuildId || ''}
+                onChange={(event) => setSelectedGuildId(event.target.value)}
+              >
+                <option value="">Escolha um servidor</option>
+                {guilds.map((guild) => (
+                  <option key={guild.id} value={guild.id}>
+                    {guild.name}
+                  </option>
+                ))}
+              </select>
+
+              <label htmlFor="sidebar-channel-select">Canal</label>
+              <select
+                id="sidebar-channel-select"
+                value={selectedChannelId || ''}
+                onChange={(event) => setSelectedChannelId(event.target.value)}
+                disabled={!selectedGuildId || channelsLoading}
+              >
+                <option value="" disabled>
+                  {selectedGuildId
+                    ? channelsLoading
+                      ? 'Carregando canais...'
+                      : 'Escolha um canal'
+                    : 'Escolha um servidor'}
+                </option>
+                {!channelsLoading &&
+                  channels.map((channel) => (
+                    <option key={channel.id} value={channel.id}>
+                      #{channel.name}
                     </option>
                   ))}
-                </select>
-              </label>
-              <label>
-                <select
-                  value={selectedChannelId || ''}
-                  onChange={(event) => setSelectedChannelId(event.target.value)}
-                  disabled={!selectedGuildId || channelsLoading}
-                >
-                  <option value="" disabled>
-                    {selectedGuildId
-                      ? channelsLoading
-                        ? 'Carregando canais...'
-                        : 'Escolha um canal'
-                      : 'Escolha um servidor'}
-                  </option>
-                  {!channelsLoading &&
-                    channels.map((channel) => (
-                      <option key={channel.id} value={channel.id}>
-                        #{channel.name}
-                      </option>
-                    ))}
-                </select>
-              </label>
+              </select>
             </>
           )}
 

--- a/dashboard/frontend/src/components/ui/Topbar.jsx
+++ b/dashboard/frontend/src/components/ui/Topbar.jsx
@@ -1,0 +1,15 @@
+export default function Topbar({ user, onLogout }) {
+  return (
+    <header className="topbar">
+      <div>
+        <h1>Little Boat Poll</h1>
+        <p role="status">
+          Logado como <strong>{user?.username || '---'}</strong>
+        </p>
+      </div>
+      <button className="button secondary" onClick={onLogout} type="button">
+        Sair
+      </button>
+    </header>
+  );
+}

--- a/dashboard/frontend/src/styles.css
+++ b/dashboard/frontend/src/styles.css
@@ -1,29 +1,37 @@
 :root {
   font-family: Inter, Arial, sans-serif;
-  color: #e2e8f0;
-  background: #0d1117;
+  color: #dcddde;
+  background: #161b22;
 
-  /* ── Color tokens ─────────────────────────── */
-  --bg: #0d1117;
-  --surface: #161b27;
-  --surface-alt: #1c2333;
-  --border: #2a3347;
-  --border-light: #222d42;
+  /* ── Discord-like color tokens ─────────────────────────── */
+  --bg: #161b22;
+  --surface: #2f3136;
+  --surface-alt: #202225;
+  --surface-strong: #393a41;
+  --surface-stronger: #36393f;
+  --surface-panel: #2f3136;
 
-  --text-primary: #e2e8f0;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
+  --border: #2f3136;
+  --border-light: #393c43;
+  --border-muted: #2f5a8d;
 
-  --accent: #00b4d8;
-  /* ciano brilhante */
-  --accent-bg: #0a2535;
-  --accent-text: #38bdf8;
-  --accent-ring: rgba(0, 180, 216, 0.25);
+  --text-primary: #dcddde;
+  --text-secondary: #8e9297;
+  --text-muted: #72767d;
+  --text-inverted: #0d1117;
+  --text-warning: #ffe4e4;
 
-  --btn-secondary: #1e2d45;
-  --btn-danger: #ef4444;
+  --accent: #767785;
+  --accent-bg: #2f3136;
+  --accent-text: #ffffff;
+  --accent-ring: rgba(87, 94, 172, 0.35);
 
-  --code-bg: #090e18;
+  --btn-primary: #5865f2;
+  --btn-secondary: #4f5667;
+  --btn-danger: #eb4d5c;
+  --btn-primary-text: #ffffff;
+
+  --code-bg: #1f2329;
   --code-text: #7dd3fc;
 
   --success-bg: #052e16;
@@ -33,6 +41,26 @@
   --error-bg: #1f0707;
   --error-text: #f87171;
   --error-border: #7f1d1d;
+
+  --selected-border: #4f5664;
+  --legend-draft: #9f7aea;
+
+  --sidebar-item: #393a41;
+  --sidebar-item-active: #4b4d57;
+  --sidebar-item-active-alt: #4f545c;
+
+  --sidebar-warning-bg: #661010;
+  --sidebar-warning-text: #ffe4e4;
+
+  --channel-required-border: #00b4d8;
+  --channel-required-bg: #0a2535;
+  --channel-hint: #38bdf8;
+
+  --focus-ring: rgba(88, 101, 242, 0.25);
+  --focus-ring-dark: rgba(52, 57, 66, 0.45);
+
+  --shadow-heavy: rgba(0, 0, 0, 0.45);
+  --shadow-soft: rgba(0, 0, 0, 0.4);
 }
 
 * {
@@ -117,11 +145,15 @@ textarea {
 
 .button {
   border: none;
-  background: var(--accent);
-  color: #fff;
+  background: var(--btn-primary);
+  color: var(--btn-primary-text);
   padding: 10px 14px;
   border-radius: 8px;
   cursor: pointer;
+}
+
+.button.secondary {
+  background: var(--btn-secondary);
 }
 
 .button:disabled {
@@ -217,6 +249,31 @@ textarea {
 .command-group-column {
   min-width: 0;
   align-self: start;
+  background: var(--surface-strong);
+  border: 1px solid var(--surface-strong);
+  border-radius: 12px;
+  padding: 10px;
+}
+
+.command-option {
+  border: 1px solid var(--surface-strong);
+  border-radius: 10px;
+  background: var(--surface);
+  overflow: hidden;
+  contain: layout paint;
+}
+
+.command-item {
+  background: var(--surface);
+  border: 1px solid var(--surface-alt);
+  color: var(--text-primary);
+}
+
+.command-panel-content {
+  background: var(--surface);
+  border: 1px solid var(--surface);
+  border-radius: 8px;
+  color: var(--text-primary);
 }
 
 .command-list {
@@ -226,9 +283,9 @@ textarea {
 }
 
 .command-option {
-  border: 1px solid var(--border-light);
+  border: 1px solid var(--surface-strong);
   border-radius: 10px;
-  background: var(--surface);
+  background: var(--surface-strong);
   overflow: hidden;
   contain: layout paint;
 }
@@ -239,9 +296,9 @@ textarea {
 }
 
 .command-item {
-  border: none;
-  border-radius: 0;
-  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--surface-stronger);
   text-align: left;
   padding: 10px;
   display: grid;
@@ -252,7 +309,8 @@ textarea {
   min-height: 84px;
   transition:
     background-color 0.2s ease,
-    color 0.2s ease;
+    color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .command-item span {
@@ -262,8 +320,13 @@ textarea {
 }
 
 .command-item.selected {
-  border-color: transparent;
-  background: var(--accent-bg);
+  border-color: var(--selected-border);
+  background: var(--surface);
+}
+
+.command-item-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .command-item-header {
@@ -297,6 +360,9 @@ textarea {
   min-width: 0;
   overflow-x: hidden;
   min-height: 240px;
+  background: var(--surface-panel);
+  border: 1px solid var(--border-muted);
+  border-radius: 8px;
   visibility: hidden;
   opacity: 0;
   transform: translateY(-6px);
@@ -518,6 +584,298 @@ textarea {
   margin: 0;
 }
 
+/* New layout components */
+.dashboard-shell {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  max-width: 1140px;
+  min-height: 85vh;
+  margin: 24px auto;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 15px 40px var(--shadow-heavy);
+  background: var(--surface-alt);
+}
+
+.sidebar {
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  padding: 20px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+  min-height: 0;
+}
+
+.sidebar-item {
+  background: var(--sidebar-item);
+  border: 1px solid var(--sidebar-item);
+}
+
+.sidebar-item.active,
+.sidebar-item:hover {
+  background: var(--sidebar-item-active-alt);
+  border-color: var(--sidebar-item-active-alt);
+}
+
+.sidebar-item {
+  border: 1px solid var(--sidebar-item);
+}
+
+.sidebar-item.active,
+.sidebar-item:hover {
+  background: var(--sidebar-item-active);
+  border-color: var(--sidebar-item-active);
+  box-shadow: 0 0 0 2px var(--focus-ring-dark);
+}
+
+.sidebar-title {
+  color: var(--text-primary);
+  font-size: 1.4rem;
+  margin: 0;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.sidebar-server-channel {
+  border-top: 1px solid var(--border);
+  margin-top: 16px;
+  padding-top: 14px;
+}
+
+.sidebar-server-channel h3 {
+  margin: 0 0 8px 0;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-align: center;
+}
+
+.sidebar-server-channel label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.92rem;
+  line-height: 1.2;
+}
+
+.sidebar-server-channel select {
+  margin-top: 4px;
+}
+
+.sidebar-server-channel select {
+  width: 100%;
+  min-width: 0;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid var(--btn-secondary);
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.sidebar-server-channel select:focus {
+  outline: none;
+  border-color: var(--btn-primary);
+  box-shadow: 0 0 0 2px var(--focus-ring);
+}
+
+.sidebar-warning {
+  margin-top: 10px;
+  padding: 8px;
+  background: var(--sidebar-warning-bg);
+  border-radius: 8px;
+  color: var(--sidebar-warning-text);
+  font-size: 0.86rem;
+}
+
+.sidebar-item {
+  width: 100%;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--surface);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.sidebar-item.active,
+.sidebar-item:hover {
+  background: var(--sidebar-item-active);
+  color: var(--accent-text);
+  border-color: var(--sidebar-item-active);
+  box-shadow: 0 0 0 2px var(--focus-ring-dark);
+}
+
+.dashboard-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 70vh;
+  max-height: 92vh;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 14px 20px;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.dashboard-content {
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.user-access-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.user-access-row span {
+  margin: 0;
+  font-weight: 500;
+}
+
+.dashboard-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.stat-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.stat-card strong {
+  font-size: 1.8rem;
+  color: var(--accent-text);
+}
+
+.stat-card span {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.stat-card small {
+  color: var(--text-secondary);
+}
+
+.chart-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 14px;
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: center;
+  gap: 12px;
+}
+
+.donut-chart {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  margin: 0 auto;
+  background: conic-gradient(
+    var(--accent) 0 calc(var(--percentage) * 1%),
+    var(--border-light) calc(var(--percentage) * 1%) 100%
+  );
+  position: relative;
+}
+
+.donut-chart span {
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.chart-legend {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+}
+
+.legend-square {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 6px;
+  border-radius: 2px;
+}
+
+.legend-poll {
+  background: var(--accent);
+}
+
+.legend-draft {
+  background: var(--legend-draft);
+}
+
+.panel h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  color: var(--text-primary);
+}
+
+@media (max-width: 1024px) {
+  .dashboard-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-around;
+  }
+
+  .sidebar-list {
+    display: flex;
+    gap: 6px;
+  }
+
+  .dashboard-main {
+    min-height: auto;
+  }
+}
+
 .csv-submit-button {
   width: auto;
   min-width: 132px;
@@ -672,10 +1030,56 @@ textarea {
   }
 }
 
+@media (max-width: 600px) {
+  .dashboard-shell {
+    grid-template-columns: 1fr;
+    max-width: 100%;
+    margin: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 12px;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .sidebar.mobile .sidebar-server-channel {
+    display: none;
+  }
+
+  .sidebar-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .sidebar-item {
+    width: 100%;
+  }
+
+  .dashboard-main {
+    min-height: auto;
+    max-height: none;
+  }
+
+  .dashboard-content {
+    padding: 12px;
+  }
+
+  .command-groups {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* ── Channel selector warning ─────────────────────────── */
 .channel-selector-row.channel-required {
-  border-color: #00b4d8;
-  background: #0a2535;
+  border-color: var(--channel-required-border);
+  background: var(--channel-required-bg);
 }
 
 .channel-warning-icon {
@@ -685,23 +1089,23 @@ textarea {
 .channel-hint {
   margin: 4px 0 0;
   font-size: 13px;
-  color: #38bdf8;
+  color: var(--channel-hint);
   font-weight: 500;
 }
 
 .channel-required-banner {
-  background: #0a2535;
-  border: 1px solid #00b4d8;
+  background: var(--channel-required-bg);
+  border: 1px solid var(--channel-required-border);
   border-radius: 8px;
   padding: 10px 12px;
   font-size: 14px;
   font-weight: 600;
-  color: #38bdf8;
+  color: var(--channel-hint);
   margin-bottom: 16px;
 }
 
 .channel-selector-row.channel-required label {
-  color: #38bdf8;
+  color: var(--channel-hint);
 }
 
 .commands-disabled {
@@ -712,7 +1116,7 @@ textarea {
 
 /* ── Tema escuro refinado ─────────────────────────── */
 .card {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 1px 3px var(--shadow-soft);
 }
 
 .guild-card:hover,
@@ -731,7 +1135,7 @@ select {
 
 .button {
   background: var(--accent);
-  color: #0d1117;
+  color: var(--text-inverted);
   font-weight: 600;
 }
 

--- a/src/commands/polls/draft.js
+++ b/src/commands/polls/draft.js
@@ -508,6 +508,7 @@ async function handlePublicar(interaction, client) {
       maxVotos: draft.maxVotos,
       usarPesoMensalista: draft.usarPesoMensalista,
       criadoEm: new Date(),
+      criadoPor: draft.criadorId || interaction.user?.id || null,
       votos: {},
       status: 'ativa',
     });

--- a/src/commands/polls/poll.js
+++ b/src/commands/polls/poll.js
@@ -135,6 +135,7 @@ module.exports = {
         maxVotos: maxVotos,
         usarPesoMensalista: usarPesoMensalista,
         criadoEm: new Date(),
+        criadoPor: interaction.user?.id || null,
         votos: {}, // userId -> { reacoes: [emoji1, emoji2], peso: 2 ou 1 }
         status: 'ativa',
       });


### PR DESCRIPTION
Introduce a new user interface flow for the dashboard and include the creatorId in the poll payload to enhance poll management features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard with section-based navigation (Painel, Comandos, Importação CSV) and new layout components
  * Guild & channel selection UI with mobile-responsive placement
  * Command management UI with expandable command panels, forms and status feedback
  * Topbar showing user status and logout

* **Styling**
  * New theme tokens and refined responsive/dashboard visuals

* **Bug Fixes**
  * Polls now include creator information in their data/state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->