### PR TITLE
Add Windows twemoji fallback and use in picker

### DIFF
--- a/dashboard/frontend/src/app/components/EmojiRenderer.test.tsx
+++ b/dashboard/frontend/src/app/components/EmojiRenderer.test.tsx
@@ -2,7 +2,20 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import EmojiRenderer from './EmojiRenderer';
 
+const originalUserAgent = window.navigator.userAgent;
+
+function setUserAgent(value: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value,
+    configurable: true,
+  });
+}
+
 describe('EmojiRenderer', () => {
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+  });
+
   it('falls back to a safe placeholder when the emoji asset fails to load', async () => {
     render(<EmojiRenderer emojiId="123456789012345678" emojiAnimated={false} alt="Emoji de teste" />);
 
@@ -19,5 +32,20 @@ describe('EmojiRenderer', () => {
     render(<EmojiRenderer emoji="😀" />);
 
     expect(screen.getByText('😀')).toBeInTheDocument();
+  });
+
+  it('renders unicode emoji as image on Windows and falls back to text on error', async () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+
+    render(<EmojiRenderer emoji="🇧🇷" alt="Bandeira" />);
+
+    const image = screen.getByRole('img', { name: 'Bandeira' });
+    expect(image).toHaveAttribute('src', expect.stringContaining('1f1e7-1f1f7.svg'));
+
+    fireEvent.error(image);
+
+    await waitFor(() => {
+      expect(screen.getByText('🇧🇷')).toBeInTheDocument();
+    });
   });
 });

--- a/dashboard/frontend/src/app/components/EmojiRenderer.tsx
+++ b/dashboard/frontend/src/app/components/EmojiRenderer.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { getDiscordEmojiUrlFromEmoji } from '../lib/emoji-merge';
+import { getUnicodeEmojiImageUrl, shouldRenderUnicodeEmojiAsImage } from '../lib/emoji-rendering';
 
 interface Props {
   emoji?: string | null;
@@ -39,8 +40,14 @@ function renderCustomEmojiFallback(className: string, alt: string) {
 }
 
 export function EmojiRenderer({ emoji, emojiId, emojiAnimated, emojiUrl, className = '', alt = '' }: Props) {
-  const [imageFailed, setImageFailed] = useState(false);
+  const [customImageFailed, setCustomImageFailed] = useState(false);
+  const [unicodeImageFailed, setUnicodeImageFailed] = useState(false);
   const fallbackAlt = alt || 'emoji indisponível';
+
+  useEffect(() => {
+    setCustomImageFailed(false);
+    setUnicodeImageFailed(false);
+  }, [emoji, emojiId, emojiAnimated, emojiUrl]);
 
   // Prefer explicit URL/id metadata provided by the API.
   const resolvedEmojiId = emojiId || parseDiscordIdentifier(emoji)?.id || parseLegacyEmojiId(emoji)?.id || null;
@@ -52,14 +59,14 @@ export function EmojiRenderer({ emoji, emojiId, emojiAnimated, emojiUrl, classNa
     (resolvedEmojiId ? getDiscordEmojiUrlFromEmoji({ id: resolvedEmojiId, animated: resolvedAnimated } as any) : null);
 
   if (resolvedCustomEmojiUrl) {
-    if (!imageFailed) {
+    if (!customImageFailed) {
       return (
         <img
           src={resolvedCustomEmojiUrl}
           alt={alt || 'emoji'}
           className={className}
           loading="lazy"
-          onError={() => setImageFailed(true)}
+          onError={() => setCustomImageFailed(true)}
         />
       );
     }
@@ -72,9 +79,15 @@ export function EmojiRenderer({ emoji, emojiId, emojiAnimated, emojiUrl, classNa
   if (parsed) {
     const url = getDiscordEmojiUrlFromEmoji({ id: parsed.id, animated: parsed.animated } as any);
 
-    if (!imageFailed) {
+    if (!customImageFailed) {
       return (
-        <img src={url} alt={alt || 'emoji'} className={className} loading="lazy" onError={() => setImageFailed(true)} />
+        <img
+          src={url}
+          alt={alt || 'emoji'}
+          className={className}
+          loading="lazy"
+          onError={() => setCustomImageFailed(true)}
+        />
       );
     }
 
@@ -85,13 +98,33 @@ export function EmojiRenderer({ emoji, emojiId, emojiAnimated, emojiUrl, classNa
   if (legacyParsed) {
     const url = getDiscordEmojiUrlFromEmoji({ id: legacyParsed.id, animated: legacyParsed.animated } as any);
 
-    if (!imageFailed) {
+    if (!customImageFailed) {
       return (
-        <img src={url} alt={alt || 'emoji'} className={className} loading="lazy" onError={() => setImageFailed(true)} />
+        <img
+          src={url}
+          alt={alt || 'emoji'}
+          className={className}
+          loading="lazy"
+          onError={() => setCustomImageFailed(true)}
+        />
       );
     }
 
     return renderCustomEmojiFallback(className, fallbackAlt);
+  }
+
+  const unicodeImageUrl = shouldRenderUnicodeEmojiAsImage(emoji) ? getUnicodeEmojiImageUrl(emoji) : null;
+
+  if (unicodeImageUrl && !unicodeImageFailed) {
+    return (
+      <img
+        src={unicodeImageUrl}
+        alt={alt || 'emoji'}
+        className={className}
+        loading="lazy"
+        onError={() => setUnicodeImageFailed(true)}
+      />
+    );
   }
 
   // Fallback to rendering the emoji as text (unicode)

--- a/dashboard/frontend/src/app/components/PollEmojiPickerField.tsx
+++ b/dashboard/frontend/src/app/components/PollEmojiPickerField.tsx
@@ -4,6 +4,7 @@ import { Smile } from 'lucide-react';
 import { Button } from './ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import type { UnifiedEmoji } from '../lib/emoji-merge';
+import { getUnicodeEmojiImageUrl, shouldRenderUnicodeEmojiAsImage } from '../lib/emoji-rendering';
 
 type EmojiPickerCustomEntry = {
   id: string;
@@ -33,6 +34,7 @@ export const PollEmojiPickerField = memo(
   }: PollEmojiPickerFieldProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [pickerEmojis, setPickerEmojis] = useState<UnifiedEmoji[]>([]);
+    const [unicodePreviewFailed, setUnicodePreviewFailed] = useState(false);
 
     useEffect(() => {
       if (isOpen) {
@@ -44,6 +46,19 @@ export const PollEmojiPickerField = memo(
     }, [emojis, isOpen]);
 
     const selectedEmoji = useMemo(() => emojis.find((emoji) => emoji.value === value) ?? null, [emojis, value]);
+
+    useEffect(() => {
+      setUnicodePreviewFailed(false);
+    }, [selectedEmoji?.unicode]);
+
+    const unicodeImageUrl = useMemo(
+      () => (selectedEmoji?.unicode ? getUnicodeEmojiImageUrl(selectedEmoji.unicode) : null),
+      [selectedEmoji?.unicode],
+    );
+
+    const shouldRenderUnicodeImage = Boolean(unicodeImageUrl)
+      ? shouldRenderUnicodeEmojiAsImage(selectedEmoji?.unicode ?? null)
+      : false;
 
     const customEmojis = useMemo<EmojiPickerCustomEntry[]>(
       () =>
@@ -99,9 +114,21 @@ export const PollEmojiPickerField = memo(
               />
             )}
             {!selectedEmoji?.isCustom && selectedEmoji?.unicode && (
-              <span className="text-base leading-none" aria-hidden="true">
-                {selectedEmoji.unicode}
-              </span>
+              <>
+                {shouldRenderUnicodeImage && unicodeImageUrl && !unicodePreviewFailed ? (
+                  <img
+                    src={unicodeImageUrl}
+                    alt={`Emoji ${selectedEmoji.name}`}
+                    className="size-5 object-contain"
+                    loading="lazy"
+                    onError={() => setUnicodePreviewFailed(true)}
+                  />
+                ) : (
+                  <span className="text-base leading-none" aria-hidden="true">
+                    {selectedEmoji.unicode}
+                  </span>
+                )}
+              </>
             )}
             {!selectedEmoji && <Smile className="size-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />}
           </Button>

--- a/dashboard/frontend/src/app/components/PollEmojiPickerField.tsx
+++ b/dashboard/frontend/src/app/components/PollEmojiPickerField.tsx
@@ -4,7 +4,11 @@ import { Smile } from 'lucide-react';
 import { Button } from './ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import type { UnifiedEmoji } from '../lib/emoji-merge';
-import { getUnicodeEmojiImageUrl, shouldRenderUnicodeEmojiAsImage } from '../lib/emoji-rendering';
+import {
+  getUnicodeEmojiImageUrl,
+  shouldRenderUnicodeEmojiAsImage,
+  shouldUseTwemojiInPicker,
+} from '../lib/emoji-rendering';
 
 type EmojiPickerCustomEntry = {
   id: string;
@@ -94,6 +98,8 @@ export const PollEmojiPickerField = memo(
       '--epr-search-input-height': '38px',
     } as CSSProperties;
 
+    const pickerEmojiStyle = shouldUseTwemojiInPicker() ? EmojiStyle.TWITTER : EmojiStyle.NATIVE;
+
     return (
       <Popover open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild>
@@ -139,7 +145,7 @@ export const PollEmojiPickerField = memo(
             onEmojiClick={handleEmojiClick}
             searchPlaceholder="Buscar emoji"
             theme={Theme.AUTO}
-            emojiStyle={EmojiStyle.NATIVE}
+            emojiStyle={pickerEmojiStyle}
             lazyLoadEmojis
             skinTonesDisabled
             previewConfig={{ showPreview: false }}

--- a/dashboard/frontend/src/app/lib/emoji-rendering.ts
+++ b/dashboard/frontend/src/app/lib/emoji-rendering.ts
@@ -53,3 +53,7 @@ export function shouldRenderUnicodeEmojiAsImage(emoji: string | null | undefined
 
   return isWindowsPlatform();
 }
+
+export function shouldUseTwemojiInPicker() {
+  return isWindowsPlatform();
+}

--- a/dashboard/frontend/src/app/lib/emoji-rendering.ts
+++ b/dashboard/frontend/src/app/lib/emoji-rendering.ts
@@ -27,7 +27,7 @@ function toTwemojiCodepoints(emoji: string) {
   return Array.from(emoji)
     .map((char) => char.codePointAt(0))
     .filter((codepoint): codepoint is number => typeof codepoint === 'number')
-    .map((codepoint) => codepoint.toString(16).padStart(4, '0'))
+    .map((codepoint) => codepoint.toString(16))
     .join('-');
 }
 

--- a/dashboard/frontend/src/app/lib/emoji-rendering.ts
+++ b/dashboard/frontend/src/app/lib/emoji-rendering.ts
@@ -1,0 +1,55 @@
+import { isValidDiscordUnicodeEmoji } from './emoji-validation';
+
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
+const TWEMOJI_BASE_URL = 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg';
+
+function isBrowserEnvironment() {
+  return typeof window !== 'undefined' && typeof navigator !== 'undefined';
+}
+
+function isWindowsPlatform() {
+  if (!isBrowserEnvironment()) return false;
+
+  const navigatorWithUAData = navigator as NavigatorWithUAData;
+  if (navigatorWithUAData.userAgentData?.platform) {
+    return /windows/i.test(navigatorWithUAData.userAgentData.platform);
+  }
+
+  return /windows/i.test(navigator.userAgent);
+}
+
+function toTwemojiCodepoints(emoji: string) {
+  return Array.from(emoji)
+    .map((char) => char.codePointAt(0))
+    .filter((codepoint): codepoint is number => typeof codepoint === 'number')
+    .map((codepoint) => codepoint.toString(16).padStart(4, '0'))
+    .join('-');
+}
+
+export function getUnicodeEmojiImageUrl(emoji: string | null | undefined) {
+  if (!emoji || typeof emoji !== 'string') return null;
+
+  const normalized = emoji.trim();
+  if (!normalized) return null;
+  if (!isValidDiscordUnicodeEmoji(normalized)) return null;
+
+  const codepoints = toTwemojiCodepoints(normalized);
+  if (!codepoints) return null;
+
+  return `${TWEMOJI_BASE_URL}/${codepoints}.svg`;
+}
+
+export function shouldRenderUnicodeEmojiAsImage(emoji: string | null | undefined) {
+  if (!emoji || typeof emoji !== 'string') return false;
+
+  const normalized = emoji.trim();
+  if (!normalized) return false;
+  if (!isValidDiscordUnicodeEmoji(normalized)) return false;
+
+  return isWindowsPlatform();
+}

--- a/dashboard/frontend/src/app/pages/CreatePoll.test.tsx
+++ b/dashboard/frontend/src/app/pages/CreatePoll.test.tsx
@@ -123,6 +123,7 @@ jest.mock('emoji-picker-react', () => {
     default: EmojiPicker,
     EmojiStyle: {
       NATIVE: 'native',
+      TWITTER: 'twitter',
     },
     Theme: {
       AUTO: 'auto',

--- a/dashboard/frontend/src/app/pages/PollDrafts.test.tsx
+++ b/dashboard/frontend/src/app/pages/PollDrafts.test.tsx
@@ -135,6 +135,7 @@ jest.mock('emoji-picker-react', () => {
     default: EmojiPicker,
     EmojiStyle: {
       NATIVE: 'native',
+      TWITTER: 'twitter',
     },
     Theme: {
       AUTO: 'auto',


### PR DESCRIPTION
This pull request improves emoji rendering across the application, especially for Windows users, by introducing Twemoji SVG image rendering for Unicode emojis when appropriate. It also enhances emoji picker consistency and error handling for emoji image fallbacks. The main changes are grouped below.

**Emoji Rendering Enhancements:**

* Added a new utility module `emoji-rendering.ts` that detects the user's platform and determines whether Unicode emojis should be rendered as images (using Twemoji SVGs) on Windows, along with helpers to generate Twemoji image URLs.
* Updated `EmojiRenderer.tsx` to render Unicode emojis as images on Windows, fall back to text if the image fails to load, and reset error state when emoji props change. [[1]](diffhunk://#diff-88eaa61787bb990ad1098d9804d3c11d19879e2eee6e9b419da1e90caf10c574L1-R3) [[2]](diffhunk://#diff-88eaa61787bb990ad1098d9804d3c11d19879e2eee6e9b419da1e90caf10c574L42-R51) [[3]](diffhunk://#diff-88eaa61787bb990ad1098d9804d3c11d19879e2eee6e9b419da1e90caf10c574L55-R69) [[4]](diffhunk://#diff-88eaa61787bb990ad1098d9804d3c11d19879e2eee6e9b419da1e90caf10c574L75-R90) [[5]](diffhunk://#diff-88eaa61787bb990ad1098d9804d3c11d19879e2eee6e9b419da1e90caf10c574L88-R129)

**Emoji Picker Improvements:**

* Modified `PollEmojiPickerField.tsx` to use Twemoji images in the emoji picker on Windows, show a Unicode emoji preview as an image when appropriate, and handle image load errors gracefully. [[1]](diffhunk://#diff-2267905ae80e4da53fff2207fd4b39a725d200f1b8f2f82b682163b34e673f4fR7-R11) [[2]](diffhunk://#diff-2267905ae80e4da53fff2207fd4b39a725d200f1b8f2f82b682163b34e673f4fR41) [[3]](diffhunk://#diff-2267905ae80e4da53fff2207fd4b39a725d200f1b8f2f82b682163b34e673f4fR54-R66) [[4]](diffhunk://#diff-2267905ae80e4da53fff2207fd4b39a725d200f1b8f2f82b682163b34e673f4fR101-R102) [[5]](diffhunk://#diff-2267905ae80e4da53fff2207fd4b39a725d200f1b8f2f82b682163b34e673f4fR123-R138) [[6]](diffhunk://#diff-2267905ae80e4da53fff2207fd4b39a725d200f1b8f2f82b682163b34e673f4fL115-R148)
* Updated emoji picker mocks in tests to support the new `TWITTER` emoji style. [[1]](diffhunk://#diff-a75389c917c2a37bcd20bc7b0a8703b0eed675338820ecf56416763fc770f452R126) [[2]](diffhunk://#diff-28397be202776edc550e0ac0506db5f91f4a3e6713c51f7e56e3a130b926f9a5R138)

**Testing Improvements:**

* Added and updated tests in `EmojiRenderer.test.tsx` to simulate different platforms by overriding the user agent, ensuring correct fallback and image rendering behavior on Windows. [[1]](diffhunk://#diff-83daea4c36fe8eb5feea88cb5ce5d8b6fe1239862833c983b12341b5e1ff1612R5-R18) [[2]](diffhunk://#diff-83daea4c36fe8eb5feea88cb5ce5d8b6fe1239862833c983b12341b5e1ff1612R36-R50)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced emoji rendering with platform-aware display logic and automatic fallback to text when images cannot load.
  * Improved emoji preview functionality in poll creation with better cross-platform compatibility support.

* **Bug Fixes**
  * Fixed emoji rendering to gracefully handle image load failures with text fallback.

* **Tests**
  * Updated test suite to validate emoji rendering behavior across different platforms and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/willianpm/LittleBoatPoll/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->